### PR TITLE
Fix Bug for encoding URI

### DIFF
--- a/build/js/SidebarSearch.js
+++ b/build/js/SidebarSearch.js
@@ -187,7 +187,7 @@ class SidebarSearch {
     }
 
     const groupItemElement = $('<a/>', {
-      href: link,
+      href: decodeURIComponent(link),
       class: 'list-group-item'
     })
     const searchTitleElement = $('<div/>', {


### PR DESCRIPTION
Encoded URI:
http%3A%2F%2F127.0.0.1%3A8001%2F
before Fixing URI displayed :
![scrnli_1_21_2022_6-55-07 PM](https://user-images.githubusercontent.com/10051801/150577666-7744ff45-bec2-4ba7-80e3-5f9f96d322b0.png)



Decoded URI:
http://127.0.0.1:8001/
after Fixing
![scrnli_1_21_2022_6-55-47 PM](https://user-images.githubusercontent.com/10051801/150577719-7e19c72f-afc8-41fc-9b4c-bb6a9aa32f9c.png)

